### PR TITLE
Fix docker env for API connectivity

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,7 +29,8 @@ JWT_EXPIRES_IN=24h
 # FRONTEND CONFIGURATION
 # ======================
 # API base URL for frontend
-VITE_API_URL=http://localhost:3000
+# For Docker deployments the frontend proxies "/api" to the backend.
+VITE_API_URL=/api
 
 # Core version for module compatibility
 VITE_CORE_VERSION=1.0.0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       - /app/node_modules
     environment:
       - NODE_ENV=development
-      - VITE_API_URL=http://backend:3000/api
+      - VITE_API_URL=http://localhost:3000/api
       - VITE_CORE_VERSION=1.0.0
     command: npm run dev -- --host 0.0.0.0
     depends_on:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,7 +9,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://sgblock-backend:5000/api/;
+    proxy_pass http://backend:3000/api/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -44,7 +44,7 @@ class ApiService {
   private token: string | null = null
 
   constructor() {
-    this.baseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+    this.baseURL = import.meta.env.VITE_API_URL || '/api'
     this.token = localStorage.getItem('authToken')
   }
 


### PR DESCRIPTION
## Summary
- fix API service default URL
- update docker compose dev API URL
- fix nginx default config for backend port
- document new API URL in env sample

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c6b94d9148325ae57be92fe0e1c30